### PR TITLE
Prevent escape keypress from emptying the editor

### DIFF
--- a/ifs-web-service/ifs-web-core/src/main/resources/static/js/vendor/wysiwyg-editor/hallo.js
+++ b/ifs-web-service/ifs-web-core/src/main/resources/static/js/vendor/wysiwyg-editor/hallo.js
@@ -315,18 +315,8 @@
         }
       },
       _keys: function(event) {
-        var old, widget;
+        var widget;
         widget = event.data;
-        if (event.keyCode === 27) {
-          old = widget.getContents();
-          widget.restoreOriginalContent(event);
-          widget._trigger("restored", null, {
-            editable: widget,
-            content: widget.getContents(),
-            thrown: old
-          });
-          return widget.turnOff();
-        }
       },
       _rangesEqual: function(r1, r2) {
         if (r1.startContainer !== r2.startContainer) {


### PR DESCRIPTION
Whilst writing applications or assessment feedback, if you press the escape key, the text editor is cleared and there's no way to retrieve the text that you've just written.

This is incredibly frustrating, especially as an assessor where your feedback is lost with no way to retrieve it, and you have to redo that section's assessment again.

This patch prevents the escape key  from clearing the editor's content, as discussed in this issue #17 

The problem is a known issue with `hallo.js` and has [also been reported upstream](https://github.com/bergie/hallo/issues/245).